### PR TITLE
Add new page for lightning talk topics using an embedded gist

### DIFF
--- a/content/pages/lightning-talks.rst
+++ b/content/pages/lightning-talks.rst
@@ -1,0 +1,23 @@
+Lightning Talks
+###############
+
+:date: 2015-05-11 21:46 
+:slug: lightning
+:author: Ashley Anderson
+:summary: Lightning Talk Topics: Suggestons and Proposals 
+:order: 02
+
+Lightning talks are short (~5 minute) presentations on small, often beginner-friendly topics.
+When possible, these talks are tacked onto the end of our regular meetings.
+Periodically we may also host a `Thunderstorm <|filename|/posts/july-2014-recap.rst>`_, a meeting consisting entirely of lightning talks.
+
+Here we will maintain a list of requested topics for lightning talks. 
+Please let us know if you have any topic suggestions!
+Likewise, let us know if you are interested in covering one of these topics at an upcoming meeting.
+
+.. raw:: html
+
+    <script src="https://gist.github.com/aganders3/5fa64dd9391103b82abc.js"></script>
+
+..  <script src="https://gist.github.com/godber/be7b6e6b0e55d4db2563.js"></script>
+


### PR DESCRIPTION
This PR adds a page that lists lightning talk topics, and fixes #4. The topic list is maintained in an embedded gist. Right now that gist is mine (https://gist.github.com/aganders3/5fa64dd9391103b82abc), but feel free to change it. There is a commented line in `lightning-talks.rst` that will instead embed @godber's gist from the page he made in the comments from issue #4.

![screenshot 2015-05-12 10 27 00](https://cloud.githubusercontent.com/assets/1231828/7593799/7bc58104-f891-11e4-80b9-b8c448903fe7.png)
