### PR TITLE
add a menu link to discourse.desertpy.org

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -10,6 +10,9 @@ TIMEZONE = 'America/Phoenix'
 
 DEFAULT_LANG = u'en'
 
+# Additional main menue items
+MENUITEMS = [('Forum', 'https://discourse.desertpy.org')]
+
 # Blogroll
 LINKS = (('Pelican', 'http://docs.notmyidea.org/alexis/pelican/'),
          ('Python.org', 'http://python.org'))


### PR DESCRIPTION
I don't know how to test that this change does what is intended, but the theme readme says this is valid.

I am also not sure that "Forum" is the best word, but I can't think of anything better at the moment.